### PR TITLE
INSTALL: Fix the linking process for the BlueView SDK

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -519,7 +519,7 @@ sudo pip install -q -U crc16
 # Visualization
 sudo pip install -q -U tqdm
 
-# The BlueView SDK for the Teledyne imaging sonar
+# Decrypt and extract the BlueView SDK for the Teledyne imaging sonar
 if [[ ! -z "$BVTSDK_PASSWORD" ]]; then
 	instlog "Decrypting and installing the BlueView SDK"
 	mkdir -p $MIL_CONFIG_DIR
@@ -530,11 +530,12 @@ if [[ ! -z "$BVTSDK_PASSWORD" ]]; then
 	if [[ ! -d $BVTSDK_DIR ]]; then
 		instwarn "Terminating installation due to incorrect password for the BlueView SDK"
 		exit 1
-
-	# If this is not being run to create a Docker image, link the SDK to mil_blueview_driver
-	elif [[ "$DOCKER" != "true" ]]; then
-		ln -s $BVTSDK_DIR $CATKIN_DIR/src/mil_common/drivers/mil_blueview_driver/bvtsdk
 	fi
+fi
+
+# If this is not being run to create a Docker image, link the BlueView SDK to mil_blueview_driver
+if [[ -d $BVTSDK_DIR && "$DOCKER" != "true" ]]; then
+	ln -s $BVTSDK_DIR $CATKIN_DIR/src/mil_common/drivers/mil_blueview_driver/bvtsdk
 fi
 
 

--- a/user_install.sh
+++ b/user_install.sh
@@ -344,7 +344,7 @@ fi
 cd $CATKIN_DIR
 git lfs install --skip-smudge
 
-# The BlueView SDK for the Teledyne imaging sonar
+# Decrypt and extract the BlueView SDK for the Teledyne imaging sonar
 if [[ ! -z "$BVTSDK_PASSWORD" ]]; then
 	instlog "Decrypting and installing the BlueView SDK"
 	mkdir -p $MIL_CONFIG_DIR
@@ -355,11 +355,12 @@ if [[ ! -z "$BVTSDK_PASSWORD" ]]; then
 	if [[ ! -d $BVTSDK_DIR ]]; then
 		instwarn "Terminating installation due to incorrect password for the BlueView SDK"
 		exit 1
-
-	# Link the SDK to mil_blueview_driver
-	else
-		ln -s $BVTSDK_DIR $CATKIN_DIR/src/mil_common/drivers/mil_blueview_driver/bvtsdk
 	fi
+fi
+
+# Link the BlueView SDK to mil_blueview_driver
+if [[ -d $BVTSDK_DIR ]]; then
+	ln -s $BVTSDK_DIR $CATKIN_DIR/src/mil_common/drivers/mil_blueview_driver/bvtsdk
 fi
 
 # Pull large project files from Git-LFS


### PR DESCRIPTION
This change fixes an issue on multi-user systems that occurs with old workspaces where the BlueView SDK is not linked in mil_blueview_driver. If the SDK had previously been decrypted and extracted, the linking process would be skipped for these workspaces.