### PR TITLE
INSTALL: Add iPython to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -488,6 +488,7 @@ sudo apt-get install -qq python-scipy
 
 # System tools
 sudo apt-get install -qq vim
+sudo apt-get install -qq ipython
 sudo apt-get install -qq tmux
 sudo apt-get install -qq htop
 sudo apt-get install -qq sshfs


### PR DESCRIPTION
Adding iPython to the install script because it's useful and a lot of us use it. 