### PR TITLE
DEPENDENCIES: install joy and serial, as needed by Navigator

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -535,6 +535,10 @@ sudo apt-get install -qq mayavi2
 
 instlog "Installing common ROS dependencies"
 
+# Hardware drivers
+sudo apt-get install -qq ros-$ROS_VERSION-joy
+sudo apt-get install -qq ros-$ROS_VERSION-serial
+
 # Messages
 sudo apt-get install -qq ros-$ROS_VERSION-tf2-sensor-msgs
 
@@ -657,9 +661,6 @@ if [[ "$INSTALL_NAV" == "true" ]]; then
 	# Serial communications
 	sudo apt-get install -qq ros-$ROS_VERSION-rosserial
 	sudo apt-get install -qq ros-$ROS_VERSION-rosserial-arduino
-
-	# Thruster driver
-	sudo apt-get install -qq ros-$ROS_VERSION-roboteq-driver
 
 	# Trajectory Generation
 	sudo apt-get install -qq ros-$ROS_VERSION-ompl


### PR DESCRIPTION
* add ros serial package as used by our custom version of roboteq driver in navigator
* add joy package to install as used for xbox joystick control
* remove install of roboteq driver, as we have our custom version in the repo as mentioned above