### PR TITLE
NAVIGATOR: remove lqRRT setup commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -626,11 +626,6 @@ if [[ "$INSTALL_NAV" == "true" ]]; then
 
 	# Trajectory Generation
 	sudo apt-get install -qq ros-$ROS_VERSION-ompl
-
-	instlog "Performing setup tasks for lqRRT"
-	cd $CATKIN_DIR/src/NaviGator/gnc/lqRRT
-	sudo python setup.py build
-	sudo python setup.py install
 fi
 
 


### PR DESCRIPTION
No longer needed as of uf-mil/Navigator#213, assuming installing for kinetic (which is all we support now)