### PR TITLE
Add latest gazebo ppa

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -337,6 +337,10 @@ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main
 sudo sh -c 'echo "deb-src http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list.d/ros.list'
 sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 
+instlog "Adding the Gazebo PPA to software sources"
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+
 
 # Add software repository for Terry Guo's ARM toolchain if NaviGator is being installed
 # This is a dependency for the emergency controller, which in its current iteration on 2017-29-08 does not work


### PR DESCRIPTION
Without adding the gazebo ppa, apt will pull a very old version of gazebo (7.0.0) from ubuntu repositories, instead of the latest.