### PR TITLE
Update Key for ROS packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -337,7 +337,7 @@ fi
 instlog "Adding the ROS PPA to software sources"
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
 sudo sh -c 'echo "deb-src http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list.d/ros.list'
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+sudo -E apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 instlog "Adding the Gazebo PPA to software sources"
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'


### PR DESCRIPTION
Old ROS package key was revoked due to a security problem and has since been replaced. This PR updates the key in the install script.

For more details: http://answers.ros.org/question/325039/apt-update-fails-cannot-install-pkgs-key-not-working/